### PR TITLE
Included screts, unit-tests and updated README

### DIFF
--- a/ComputeCS.Tests/ComputeCS.Tests.csproj
+++ b/ComputeCS.Tests/ComputeCS.Tests.csproj
@@ -1,17 +1,15 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
-
-    <PropertyGroup>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
-    </PropertyGroup>
-
-    <ItemGroup>
-      <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
-      <PackageReference Include="NUnit" Version="3.12.0" />
-      <PackageReference Include="NUnit3TestAdapter" Version="3.17.0-beta.1" />
-    </ItemGroup>
-
-    <ItemGroup>
-      <ProjectReference Include="..\ComputeCS\ComputeCS.csproj" />
-    </ItemGroup>
-
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <UserSecretsId>d259b59c-3708-4b6f-a0f9-90d9b8b3560d</UserSecretsId>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
+    <PackageReference Include="NUnit" Version="3.12.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.17.0-beta.1" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\ComputeCS\ComputeCS.csproj" />
+  </ItemGroup>
 </Project>

--- a/ComputeCS.Tests/ComputeCS.Tests.csproj
+++ b/ComputeCS.Tests/ComputeCS.Tests.csproj
@@ -8,8 +8,13 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0-beta.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.0.2" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="2.0.2" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\ComputeCS\ComputeCS.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <DotNetCliToolReference Include="Microsoft.Extensions.SecretManager.Tools" Version="2.0.0" />
   </ItemGroup>
 </Project>

--- a/ComputeCS.Tests/LoginTest.cs
+++ b/ComputeCS.Tests/LoginTest.cs
@@ -1,28 +1,30 @@
 using NUnit.Framework;
-using ComputeCS;
 using System;
-
 
 namespace ComputeCS.UnitTests.Login
 {
-
     [TestFixture]
     public class ComputeClient_computeClient
     {
-        private ComputeClient _client;
+        private UserSettings user = new UserSettings();
+
+        private ComputeClient client;
+        
         
         [SetUp]
         public void SetUp()
         {
-            _client = new ComputeClient();
+            client = new ComputeClient(user.host);
         }
 
         [Test]
         public void ComputeClient_GetToken()
         {
-            var result = _client.GetAccessToken();
+            var tokens = client.Auth(user.username, user.password);
 
-            Assert.IsNotNull(_client.GetAccessToken(), "Access token does not exist");
+            Console.WriteLine($"Got access token: {tokens.Access}");
+
+            Assert.IsNotNull(tokens.Access, "_value should be true");
         }
     }
 }

--- a/ComputeCS.Tests/LoginTest.cs
+++ b/ComputeCS.Tests/LoginTest.cs
@@ -1,0 +1,28 @@
+using NUnit.Framework;
+using ComputeCS;
+using System;
+
+
+namespace ComputeCS.UnitTests.Login
+{
+
+    [TestFixture]
+    public class ComputeClient_computeClient
+    {
+        private ComputeClient _client;
+        
+        [SetUp]
+        public void SetUp()
+        {
+            _client = new ComputeClient();
+        }
+
+        [Test]
+        public void ComputeClient_GetToken()
+        {
+            var result = _client.GetAccessToken();
+
+            Assert.IsNotNull(_client.GetAccessToken(), "Access token does not exist");
+        }
+    }
+}

--- a/ComputeCS.Tests/TestSecrets.cs
+++ b/ComputeCS.Tests/TestSecrets.cs
@@ -1,0 +1,23 @@
+using NUnit.Framework;
+using System;
+
+
+namespace ComputeCS.UnitTests.Secrets
+{
+    [TestFixture]
+    public class Secrets_secrets
+    {           
+        [Test]
+        public void Secrets_GetSecrets()
+        {
+            // Load the user class (which loads the secrets on model instantiation)
+            UserSettings user = new UserSettings();
+            Console.WriteLine($"Username: {user.username}");
+            Console.WriteLine($"Password: {user.password}");
+            Console.WriteLine($"Host: {user.host}");
+            Console.WriteLine($"Auth Host: {user.auth_host}");
+
+            Assert.IsTrue(true, "Assertions in User object creation");
+        }
+    }
+}

--- a/ComputeCS.Tests/UserSettings.cs
+++ b/ComputeCS.Tests/UserSettings.cs
@@ -1,0 +1,40 @@
+using NUnit.Framework;
+using Microsoft.Extensions.Configuration;
+
+
+namespace ComputeCS.UnitTests
+{
+
+    public class UserSettings 
+    {
+        public string username { get; set; }
+        public string password { get; set; }
+        public string host { get; set; }
+        public string auth_host { get; set; }
+
+        public UserSettings() {
+            /* Set the user login/pass from secrets. Ensure that you have done:
+            dotnet user-secrets set "ComputeAPIUser:Username" "<username>"
+            dotnet user-secrets set "ComputeAPIUser:Password" "<password>"
+            dotnet user-secrets set "ComputeAPIUser:Host" "<host>"
+
+            Ensure that host is fully qualified including http(s)://
+
+            An optional authentication host may be provided (ie. login.procedural.build).  If not provided
+            then the auth_host will be equal to the host.
+            */
+            IConfiguration configuration = new ConfigurationBuilder()
+                .AddUserSecrets<UserSettings>()
+                .Build();
+            IConfigurationSection _section = configuration.GetSection("ComputeAPIUser");
+            username = _section["Username"];
+            password = _section["Password"];
+            host = _section["Host"];
+            auth_host = _section["AuthHost"] != null ? _section["AuthHost"] : host;
+
+            Assert.IsNotNull(username, "Username secret not set. Run: dotnet user-secrets set 'ComputeAPIUser:Username' '<username>'");
+            Assert.IsNotNull(password, "Password secret not set. Run: dotnet user-secrets set 'ComputeAPIUser:Password' '<password>'");
+            Assert.IsNotNull(host, "Host secret not set. Run: dotnet user-secrets set 'ComputeAPIUser:Host' '<host>'");
+        }
+    }
+}

--- a/ComputeCS/ComputeClient.cs
+++ b/ComputeCS/ComputeClient.cs
@@ -12,6 +12,10 @@ namespace ComputeCS
         public string url = null;
         public AuthTokens Tokens = null;
 
+        public ComputeClient(string host = null) {
+            url = host;
+        }
+
         public AuthTokens Auth(string username, string password)
         {
             var client = new RESTClient

--- a/ComputeCS/ComputeClient.cs
+++ b/ComputeCS/ComputeClient.cs
@@ -2,10 +2,10 @@ using System;
 using System.Text;
 using System.Collections.Generic;
 using System.Linq;
-using computeCS.types;
+using ComputeCS.types;
 using Newtonsoft.Json;
 
-namespace computeCS
+namespace ComputeCS
 {
     public class ComputeClient
     {

--- a/ComputeCS/Projects.cs
+++ b/ComputeCS/Projects.cs
@@ -1,10 +1,10 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using computeCS.types;
+using ComputeCS.types;
 using Newtonsoft.Json;
 
-namespace computeCS
+namespace ComputeCS
 {
     public class Projects
     {

--- a/ComputeCS/RESTClient.cs
+++ b/ComputeCS/RESTClient.cs
@@ -5,7 +5,7 @@ using System.IO;
 using System.Net;
 using System.Text;
 
-namespace computeCS
+namespace ComputeCS
 {
     public enum httpVerb
     {

--- a/ComputeCS/SerializeOutput.cs
+++ b/ComputeCS/SerializeOutput.cs
@@ -1,9 +1,9 @@
 using System;
 using System.Collections.Generic;
-using computeCS.types;
+using ComputeCS.types;
 using Newtonsoft.Json;
 
-namespace computeCS
+namespace ComputeCS
 {
     public class SerializeOutput
     {

--- a/ComputeCS/Tasks.cs
+++ b/ComputeCS/Tasks.cs
@@ -1,8 +1,8 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using computeCS;
-using computeCS.types;
+using ComputeCS;
+using ComputeCS.types;
 using Newtonsoft.Json;
 
 

--- a/ComputeCS/types/Auth.cs
+++ b/ComputeCS/types/Auth.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Globalization;
 
-namespace computeCS.types
+namespace ComputeCS.types
 {
     public class AuthTokens
     {

--- a/ComputeCS/types/CFD.cs
+++ b/ComputeCS/types/CFD.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace computeCS.types
+namespace ComputeCS.types
 {
     class CFD
     {

--- a/ComputeCS/types/Mesh.cs
+++ b/ComputeCS/types/Mesh.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace computeCS.types
+namespace ComputeCS.types
 {
     class Mesh
     {

--- a/ComputeCS/types/Project.cs
+++ b/ComputeCS/types/Project.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace computeCS.types
+namespace ComputeCS.types
 {
     public class Project
     {

--- a/ComputeCS/types/System.cs
+++ b/ComputeCS/types/System.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace computeCS.types
+namespace ComputeCS.types
 {
     class System
     {

--- a/ComputeCS/types/Task.cs
+++ b/ComputeCS/types/Task.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace computeCS.types
+namespace ComputeCS.types
 {
     public class Task
     {

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM ubuntu:20.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && \
+  apt-get install -y git build-essential wget && \ 
+  wget https://packages.microsoft.com/config/ubuntu/20.04/packages-microsoft-prod.deb -O packages-microsoft-prod.deb && \
+  dpkg -i packages-microsoft-prod.deb && \
+  apt-get update && \
+  apt-get install -y apt-transport-https && \
+  apt-get update && \
+  apt-get install -y dotnet-sdk-3.1

--- a/README.md
+++ b/README.md
@@ -1,2 +1,61 @@
 # ComputeCS
-C# Client Library for Procedural Compute
+
+C# Client Library for Procedural Compute.  
+
+This library contains the core (platform-agnostic) methods for interacting with the Procedural Compute API.  It is intended that this library is imported and "wrapped" by client UI's such as Rhino/Grasshopper and Revit/Dynamo.  This wrapping can be very "thin" (ie. a Grasshopper component can easily/trivially be made that simply wraps the exact inputs and outputs of a particular function in this library.)
+
+
+## Development notes
+
+Development on this library can be done on any platform (Windows, Linux, Mac, etc) and does not require any special platform-specific libraries other than .NET.
+
+### Secrets in Development
+
+As we are developing with a live API then you will want to keep your username/password secret and NOT publish to this repository.  This can be done in C# with secret management outlined here:
+[https://docs.microsoft.com/en-us/aspnet/core/security/app-secrets?view=aspnetcore-3.1&tabs=linux]
+
+In summary do the following (on Linux):
+```
+cd ComputeCS.Tests
+dotnet user-secrets set "ComputeAPIUser:Username" "<username>"
+dotnet user-secrets set "ComputeAPIUser:Password" "<password>"
+```
+
+You can confirm that the secets have been created and saved to a local file path with the following:
+```
+cat ~/.microsoft/usersecrets/d259b59c-3708-4b6f-a0f9-90d9b8b3560d/secrets.json
+```
+
+
+### Setup for Linux development
+
+Install the .NET core libraries for development on Linux from here:
+[https://docs.microsoft.com/en-us/dotnet/core/install/linux-package-manager-ubuntu-2004]
+
+```
+wget https://packages.microsoft.com/config/ubuntu/20.04/packages-microsoft-prod.deb -O packages-microsoft-prod.deb
+sudo dpkg -i packages-microsoft-prod.deb
+
+sudo apt-get update
+sudo apt-get install apt-transport-https
+sudo apt-get update
+sudo apt-get install dotnet-sdk-3.1
+```
+
+
+### Development in Docker Container with Visual Studio Code
+
+The above steps can of course be done within a Docker container to ensure a consistent development environment in the container.  The Dockerfile is contained in this repository and can be built with:
+
+```
+docker build . -t ubuntu:dotnet-core-3.1
+```
+
+You can develop on Linux by installing Visual Studio Code with the Docker extension to enable remote debugging of code within the Docker container.  Instructions are here: 
+[https://code.visualstudio.com/docs/containers/debug-netcore]
+
+
+### Unit Testing
+
+Unit tests are managed with `NUnit`.
+[https://docs.microsoft.com/en-us/dotnet/core/testing/unit-testing-with-nunit]

--- a/README.md
+++ b/README.md
@@ -9,25 +9,9 @@ This library contains the core (platform-agnostic) methods for interacting with 
 
 Development on this library can be done on any platform (Windows, Linux, Mac, etc) and does not require any special platform-specific libraries other than .NET.
 
-### Secrets in Development
+### Setup development environments
 
-As we are developing with a live API then you will want to keep your username/password secret and NOT publish to this repository.  This can be done in C# with secret management outlined here:
-[https://docs.microsoft.com/en-us/aspnet/core/security/app-secrets?view=aspnetcore-3.1&tabs=linux]
-
-In summary do the following (on Linux):
-```
-cd ComputeCS.Tests
-dotnet user-secrets set "ComputeAPIUser:Username" "<username>"
-dotnet user-secrets set "ComputeAPIUser:Password" "<password>"
-```
-
-You can confirm that the secets have been created and saved to a local file path with the following:
-```
-cat ~/.microsoft/usersecrets/d259b59c-3708-4b6f-a0f9-90d9b8b3560d/secrets.json
-```
-
-
-### Setup for Linux development
+#### Setup for Linux development
 
 Install the .NET core libraries for development on Linux from here:
 [https://docs.microsoft.com/en-us/dotnet/core/install/linux-package-manager-ubuntu-2004]
@@ -43,7 +27,7 @@ sudo apt-get install dotnet-sdk-3.1
 ```
 
 
-### Development in Docker Container with Visual Studio Code
+#### Development in Docker Container with Visual Studio Code
 
 The above steps can of course be done within a Docker container to ensure a consistent development environment in the container.  The Dockerfile is contained in this repository and can be built with:
 
@@ -55,7 +39,33 @@ You can develop on Linux by installing Visual Studio Code with the Docker extens
 [https://code.visualstudio.com/docs/containers/debug-netcore]
 
 
-### Unit Testing
+### Setup for Testing
+
+#### Secrets in Development
+
+As we are developing with a live API then you will want to keep your username/password secret and NOT publish to this repository.  This can be done in C# with secret management outlined here:
+[https://docs.microsoft.com/en-us/aspnet/core/security/app-secrets?view=aspnetcore-3.1&tabs=linux]
+
+In summary do the following (on Linux):
+```
+cd ComputeCS.Tests
+dotnet user-secrets set "ComputeAPIUser:Username" "<username>"
+dotnet user-secrets set "ComputeAPIUser:Password" "<password>"
+dotnet user-secrets set "ComputeAPIUser:Password" "<host>"
+```
+
+You can confirm that the secets have been created and saved to a local file path with the following:
+```
+cat ~/.microsoft/usersecrets/d259b59c-3708-4b6f-a0f9-90d9b8b3560d/secrets.json
+```
+
+#### Unit Testing
 
 Unit tests are managed with `NUnit`.
 [https://docs.microsoft.com/en-us/dotnet/core/testing/unit-testing-with-nunit]
+
+Ensure that your secrets are setup as per the above section.  Then you can run tests with:
+```
+cd ComputeCS.Tests 
+dotnet test
+```


### PR DESCRIPTION
@ocni-dtu I have:
- updated the README to provide more guidance on getting the development environment up and running for both Linux and within a Docker container.  
- Provided a Dockerfile for setting up a dev environment in a container
- Updated the README to include instructions for creating secrets (for tests)
- Included Unit tests for both secrets and a basic test that logs in and gets an JWT token.  
- The unit-test for secrets will throw assertion errors with instructions for setting up the secrets if you have not done it correctly.  This is fundamental to making all the other tests work - because you need to have secrets set up for anything else to work obviously.
- Changed computeCS namespace to ComputeCS - to keep in-line with capitalisation of c#