### PR TITLE
Updated methods and general API for http requests

### DIFF
--- a/ComputeCS.Tests/ProjectTest.cs
+++ b/ComputeCS.Tests/ProjectTest.cs
@@ -1,0 +1,39 @@
+using Newtonsoft.Json;
+using NUnit.Framework;
+using System;
+using ComputeCS;
+
+namespace ComputeCS.UnitTests.Projects
+{
+    [TestFixture]
+    public class Projects_projects
+    {
+        private UserSettings user = new UserSettings();
+        private ComputeClient client;
+        
+        
+        [SetUp]
+        public void SetUp()
+        {
+            client = new ComputeClient(user.host);
+        }
+
+        [Test]
+        public void Projects_List()
+        {
+            // Get the JWT access tokens as usual
+            var tokens = client.Auth(user.username, user.password);
+            Console.WriteLine($"Got access token: {tokens.Access}");
+
+            // Instantiate the Project object
+            var projects = new ComputeCS.Projects(client);
+
+            // Get a list of Projects for this user
+            var project_list = projects.List();
+
+            Console.Write($"Got projects: {JsonConvert.SerializeObject(project_list)}");
+
+            Assert.IsNotEmpty(project_list, "Got empty project list");
+        }
+    }
+}

--- a/ComputeCS/RESTClient.cs
+++ b/ComputeCS/RESTClient.cs
@@ -3,7 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Net;
-using System.Text;
+
 
 namespace ComputeCS
 {
@@ -15,9 +15,14 @@ namespace ComputeCS
         DELETE
     }
 
-    class RESTClient
+    public class RESTClient
     {
+        private HttpWebRequest request;
+        private HttpWebResponse response = null;
+
+        public string host { get; set; }
         public string endPoint { get; set; }
+        public Dictionary<string, object> query_params { get; set; }
         public httpVerb httpMethod { get; set; }
         public Dictionary<string, object> payload { get; set; }
         public string token = null;
@@ -25,18 +30,88 @@ namespace ComputeCS
 
         public RESTClient()
         {
+            host = "";
             endPoint = "";
+            query_params = new Dictionary<string, object>();
             httpMethod = httpVerb.GET;
             payload = null;
         }
 
-        public string makeRequest()
-        {
+        public string QueryString {
+            // Serialize the dictionary of query_params
+            get { return Utils.DictToQueryString(this.query_params); }
+        }
 
-            string strResponseValue = string.Empty;
+        public string FullUrl {
+            // Construct the full URL from provided host, endPoint and stringified query_params
+            get { return $"{host}{endPoint}{QueryString}"; }
+        }
 
-            HttpWebRequest request = (HttpWebRequest)WebRequest.Create(endPoint);
+        public T Request<T>() {
+            /* Generic request that casts the response to a type provided
+            */
+            string response = requestToString();
+            return JsonConvert.DeserializeObject<T>(response);
+        }
 
+        public T Request<T>(
+            string url, 
+            Dictionary<string, object> _query_params = null,
+            httpVerb _method = httpVerb.GET, 
+            Dictionary<string, object> _payload = null
+        ) {
+            /* Generic request that casts the response to a type provided
+            */
+            endPoint = url;
+            query_params = _query_params != null ? _query_params : new Dictionary<string, object>();
+            httpMethod = _method;
+            payload = _payload != null ? _payload : payload;
+            string response = requestToString();
+            return JsonConvert.DeserializeObject<T>(response);
+        }
+
+        public T Request<T>(Dictionary<string, object> _payload = null) {
+            /* Generic request that casts the response to a type provided
+            */
+            payload = _payload;
+            string response = requestToString();
+            return JsonConvert.DeserializeObject<T>(response);
+        }
+
+        private void SetPayload() {
+            request.ContentType = "application/json";
+            using (StreamWriter swJSONPayload = new StreamWriter(request.GetRequestStream()))
+            {
+                string json = JsonConvert.SerializeObject(payload);
+                swJSONPayload.Write(json);
+                swJSONPayload.Close();
+            }
+        }
+
+        private string GetResponseString() {
+            string responseString = string.Empty;
+
+            response = (HttpWebResponse)request.GetResponse();
+
+            using (Stream responseStream = response.GetResponseStream())
+            {
+                if (responseStream != null)
+                {
+                    using (StreamReader reader = new StreamReader(responseStream))
+                    {
+                        responseString = reader.ReadToEnd();
+                    }
+                 }
+            }
+            return responseString;
+        }
+
+        public string requestToString()
+        {           
+            string responseString = string.Empty;
+
+            // Generate the request object
+            request = (HttpWebRequest)WebRequest.Create(FullUrl);
             request.Method = httpMethod.ToString();
 
             if (token != null)
@@ -46,36 +121,17 @@ namespace ComputeCS
 
             if (request.Method == "POST" && payload != null)
             {
-                request.ContentType = "application/json";
-                using (StreamWriter swJSONPayload = new StreamWriter(request.GetRequestStream()))
-                {
-                    string json = JsonConvert.SerializeObject(payload);
-                    swJSONPayload.Write(json);
-
-                    swJSONPayload.Close();
-                }
+                this.SetPayload();
             }
 
-            HttpWebResponse response = null;
-
+            // Get the response object of fallback to error message - then release resources from the request.
             try
             {
-                response = (HttpWebResponse)request.GetResponse();
-
-                using (Stream responseStream = response.GetResponseStream())
-                {
-                    if (responseStream != null)
-                    {
-                        using (StreamReader reader = new StreamReader(responseStream))
-                        {
-                            strResponseValue = reader.ReadToEnd();
-                        }
-                    }
-                }
+                responseString = GetResponseString();
             }
             catch (Exception ex)
             {
-                strResponseValue = "{\"errorMessages\":[\"" + ex.Message.ToString() + "\"],\"errors\":{}}";
+                responseString = "{\"errorMessages\":[\"" + ex.Message.ToString() + "\"],\"errors\":{}}";
             }
             finally
             {
@@ -85,7 +141,7 @@ namespace ComputeCS
                 }
             }
 
-            return strResponseValue;
+            return responseString;
         }
     }
 }

--- a/ComputeCS/Tasks.cs
+++ b/ComputeCS/Tasks.cs
@@ -10,66 +10,89 @@ namespace ComputeCS
 {
     public class Tasks
     {
-        public ComputeClient Client = null;
-        public Project Project = null;
+        public ComputeClient client = null;
+
+        public Project project = null;
         
-        public Task GetOrCreate(string taskName, bool create = false)
+        public Tasks(ComputeClient _client, Project _project) {
+            client = _client;
+            project = _project;
+            client.http.endPoint = $"/api/project/{project.UID}/task/";
+        }
+
+        public Task GetOrCreate(string name, bool create = false)
         {
-            var token = this.Client.GetAccessToken();
-            var httpClient = new RESTClient
+            /* Try to get a project from its Name/Number. If it does not exist then 
+            (optionally) create it.
+            */
+
+            // Check that at least a name or number is provided
+            if (name == null)
             {
-                endPoint = this.Client.url + $"/api/project/{Project.UID}/task/" + QueryParams(taskName),
-                httpMethod = httpVerb.GET,
-                token = token
-            };
-            var response = httpClient.makeRequest();
-            var tasks = JsonConvert.DeserializeObject<List<Task>>(response);
+                throw new ArgumentException("Please provide a task name at minimum");
+            }
+
+            // Do the Get or Create
+            try {
+                return GetByName(name);
+            } catch (ArgumentNullException) {
+                if (create) {
+                    return Create(name);
+                }
+            }
+
+            // Return null possible if no Project found and not created.
+            return null;
+        }
+
+        public Task GetByName(string name = null) 
+        {
+            var tasks = List(name);
             if (tasks.Count > 1)
             {
                 throw new ArgumentException(
-                    "Found more than one task. Please check your inputs to identify a unique task ");
+                    @"Found more than one task. Please provide a unique 
+                    task name to identify a particular task."
+                );
+            } else if (tasks.Count == 0) {
+                throw new ArgumentNullException(
+                    "No task found."
+                );
             }
-
-            if (tasks.Count == 0)
-            {
-                if (!create)
-                {
-                    throw new ArgumentException(
-                        "Did not find any task with the provided name. Please set create to true to create a new task");
-                }
-                else
-                {
-                    httpClient.endPoint = this.Client.url + $"/api/project/{Project.UID}/task/";
-                    httpClient.httpMethod = httpVerb.POST;
-                    httpClient.payload = new Dictionary<string, object>()
-                    {
-                        {"name", taskName},
-                        {"config", new Dictionary<string, string>()
-                        {
-                            {"case_dir", "foam"},
-                            {"task_type", "parent"}
-                        }}
-                    };
-                    var createResponse = httpClient.makeRequest();
-                    return JsonConvert.DeserializeObject<Task>(response);
-                }
-            }
-            else
-            {
-                return tasks.First();
-            }
+            return tasks.First();
         }
 
-        private string QueryParams(string name)
+        public List<Task> List(string name = null) 
         {
-            if (name == null)
-            {
-                throw new ArgumentException("Please provide a project name or number");
-            }
-            else
-            {
-                return $"?name={name}&parent=null";
-            }
+            /* 
+            Get a list of all Projects that this user can access 
+            Optional query parameters may be provided to filter against name or number
+            */
+            return client.Request<List<Task>>(
+                $"/api/project/{project.UID}/task/",
+                new Dictionary<string, object>() 
+                {
+                    {"name", name}
+                }
+            );
+        }
+
+        public Task Create(string name = null) {
+            /* Create a new project with provided name and number 
+            */
+            return client.Request<Task>(
+                $"/api/project/{project.UID}/task/", null,
+                httpVerb.POST,
+                new Dictionary<string, object>()
+                {
+                    {"name", name},
+                    {"config", new Dictionary<string, string>()
+                    {
+                        {"case_dir", "foam"},
+                        {"task_type", "parent"}
+                    }}
+                }
+            );
         }
     }
 }

--- a/ComputeCS/utils.cs
+++ b/ComputeCS/utils.cs
@@ -1,0 +1,21 @@
+using System;
+using System.Collections.Generic;
+
+namespace ComputeCS
+{
+    static class Utils {
+
+        public static string DictToQueryString(Dictionary<string, object> dict)
+        {
+            string query_string = "";
+            foreach (string key in dict.Keys) {
+                string var_str = Convert.ToString(dict[key]);
+                if (var_str != "") {
+                    query_string += $"&{key}={var_str}";
+                }
+            }
+            query_string = (query_string != "") ? $"?{query_string.Substring(1)}" : "";
+            return query_string;
+        }
+    }
+}


### PR DESCRIPTION
@ocni-dtu I have made big changes to the way that you call the HTTP methods.  To make the interface more "Pythonic".   So now the ComputeClient has the RESTClient inside of it as a member... and you can call a URL with an interface like this:
`
client.Request<List<Project>>(
    "/api/project/",
    new Dictionary<string, object>() 
    {
        {"name", name},
        {"number", number}
    }
);
`
This obviously hits the url "/api/project" query parameters of name and number.   Additionally you can make a POST request like this:
`
client.Request<Project>(
    "/api/project/", null,
    httpVerb.POST,
    new Dictionary<string, object>()
    {
        {"name", name},
        {"number", number}
    }
);
`
This provides no query parameters (null) - but gives the payload at the end. **Note how you are able to make the cast directly in the Request.  This is possible because I have has the Request method as a Generic that takes in a template-type.  The result will be cast to that type.**  I think this makes the whole dev API much more clean and readable.

I have also cleaned up your methods and broken them down into smaller components.  

Also added tests for Projct and Task