### PR TITLE
Added Generic ViewSet handler for CRUD operations.  Added checking of…

### DIFF
--- a/ComputeCS.Tests/LoginTest.cs
+++ b/ComputeCS.Tests/LoginTest.cs
@@ -24,6 +24,8 @@ namespace ComputeCS.UnitTests.Login
 
             Console.WriteLine($"Got access token: {tokens.Access}");
 
+            Console.Write($"Decoded token: {ComputeClient.DecodeTokenToJson(tokens.Access)}");
+
             Assert.IsNotNull(tokens.Access, "_value should be true");
         }
     }

--- a/ComputeCS/GenericViewSet.cs
+++ b/ComputeCS/GenericViewSet.cs
@@ -1,0 +1,174 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using ComputeCS.types;
+using Newtonsoft.Json;
+
+namespace ComputeCS
+{
+    /* Handles a Generic ViewSet of endpoints with standard CRUD operations
+    (LIST, RETRIEVE, CREATE, UPDATE, PARTIAL_UPDATE & DELETE).
+
+    This is a Generic version of the Project and Task models that supports the same
+    operations with a more generic interface.  Like this:
+    ```
+    var viewset = new GenericViewSet<Project>(tokens, "/api/project/");
+
+    // Get a list of Projects like this
+    var projects = viewset.List()
+
+    // Get a single Project like this
+    var project = viewset.Retrieve("<project_uuid>")
+
+    // Create a single Project like this
+    var project = viewset.Create(Dictionary<string, object> data)
+    ```
+    */
+    public class GenericViewSet<ObjectType>
+    {
+        public ComputeClient client = null;
+        private string basePath = "";
+        
+        public GenericViewSet(ComputeClient _client, string _basePath) {
+            basePath = _basePath;
+            client = _client;
+            client.http.endPoint = _basePath;
+            client.http.httpMethod = httpVerb.GET;
+        }
+
+        public GenericViewSet(AuthTokens tokens, string basePath) {
+            client = new ComputeClient(tokens);
+            client.http.endPoint = basePath;
+            client.http.httpMethod = httpVerb.GET;
+        }
+
+        public string ObjectPath(string objectId) {
+            return $"{basePath}{(basePath.EndsWith("/") ? "" : "/")}{objectId}/";
+        }
+
+        public ObjectType GetOrCreate(Dictionary<string, object> query_params, bool create = false)
+        {
+            /* Try to get an object by filtering using query parameters from a List request. 
+            If a single filtered item does not exist then (optionally) create it.
+            */
+
+            // Check that at least a name or number is provided
+            if (query_params.Keys.Count == 0)
+            {
+                throw new ArgumentException("Please provide some query parameters for filtering the List request at a minimum");
+            }
+
+            // Do the Get or Create
+            try {
+                return GetByNameNumber(query_params);
+            } catch (ArgumentNullException) {
+                if (create) {
+                    return Create(query_params, query_params);
+                }
+            }
+
+            // Return null possible if no Project found and not created.
+            return default(ObjectType);
+        }
+
+        public ObjectType GetByNameNumber(Dictionary<string, object> query_params) 
+        {
+            var items = List(query_params);
+            if (items.Count > 1)
+            {
+                throw new ArgumentException(
+                    @"Found more than one object that match those query params. 
+                    Please provide both a project number and a name to identify an unique project"
+                );
+            } else if (items.Count == 0) {
+                throw new ArgumentNullException(
+                    "No object found."
+                );
+            }
+            return items.First();
+        }
+
+        public List<ObjectType> List(Dictionary<string, object> query_params) 
+        {
+            /* Get a list of all Projects that this user can access 
+            Optional query parameters may be provided to filter against name or number
+            */
+            return client.Request<List<ObjectType>>(
+                basePath, 
+                query_params,
+                httpVerb.GET
+            );
+        }
+
+        public ObjectType Retrieve(
+            string objectId,
+            Dictionary<string, object> query_params
+        ) {
+            /* Create a new project with provided name and number 
+            */
+            return client.Request<ObjectType>(
+                ObjectPath(objectId), 
+                query_params,
+                httpVerb.GET
+            );
+        }
+
+        public ObjectType Create(
+            Dictionary<string, object> data,
+            Dictionary<string, object> query_params
+        ) {
+            /* Create a new project with provided name and number 
+            */
+            return client.Request<ObjectType>(
+                basePath,  
+                query_params,
+                httpVerb.POST,
+                data
+            );
+        }
+
+        public ObjectType Update(
+            string objectId,
+            Dictionary<string, object> query_params,
+            Dictionary<string, object> data
+        ) {
+            /* Create a new project with provided name and number 
+            */
+            return client.Request<ObjectType>(
+                ObjectPath(objectId), 
+                query_params,
+                httpVerb.PUT,
+                data
+            );
+        }
+
+        public ObjectType PartialUpdate(
+            string objectId,
+            Dictionary<string, object> query_params,
+            Dictionary<string, object> data
+        ) {
+            /* Create a new project with provided name and number 
+            */
+            return client.Request<ObjectType>(
+                ObjectPath(objectId), 
+                query_params,
+                httpVerb.PATCH,
+                data
+            );
+        }
+
+        public ObjectType Delete(
+            string objectId,
+            Dictionary<string, object> query_params = null
+        ) {
+            /* Create a new project with provided name and number 
+            */
+            return client.Request<ObjectType>(
+                ObjectPath(objectId), 
+                query_params,
+                httpVerb.DELETE
+            );
+        }
+
+    }
+}

--- a/ComputeCS/RESTClient.cs
+++ b/ComputeCS/RESTClient.cs
@@ -12,6 +12,7 @@ namespace ComputeCS
         GET,
         POST,
         PUT,
+        PATCH,
         DELETE
     }
 


### PR DESCRIPTION
@ocni-dtu I noticed that the Task and Project classes (in Task.cs and Project.cs) are basically identical.  So I have made them into a Generic class which I have called GenericViewSet. **I have written this blind so it may not work straight out of the box - requires tests and testing!!**

The idea is that for standard Django Rest Framework type ViewSets then we only have to provide the type of the object that we get back - then this class will mirror the various requests that can be made to that viewset.  So for example a Project ViewSet can be called like this:
```
// Instantiate the GenericViewSet handler class with the type "Project".  (I have assumed that we also provide tokens that have been retrieved from a serialized pipeline).  You also need the "base_path" of the viewset.
var viewset = new GenericViewSet<Project>(tokens, "/api/project/");

// Get a list of Projects like this
var projects = viewset.List()

// Get a single Project like this
var project = viewset.Retrieve("<project_uuid>")

// Create a single Project like this
var project = viewset.Create(Dictionary<string, object> data)
```

I have also updated the ComputeClient so that different authentication and request hosts may be used.  For example, token retrieval and authentication might be done to "https://login.procedural.build" but then basic requests are done to "https://compute.procedural.build".  These hosts may be contained within the tokens so that we don't need to pass that parameter down a pipeline separately.